### PR TITLE
fix(docs): 修改 shell 注释，请复制后的命令可以直接运行

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-co
 
 ```
 systemctl start docker
-//将docker设置成开机自启动
+# 将docker设置成开机自启动
 systemctl enable docker.service
 ```
 


### PR DESCRIPTION
将 shell 的注释从 `//` 修改为 `#`，这样复制后的命令可以直接运行。